### PR TITLE
Adding Changeling template

### DIFF
--- a/CityOfBinds/__init__.py
+++ b/CityOfBinds/__init__.py
@@ -10,6 +10,10 @@ from .src.content_publisher.bfg_publisher import BFGPublisher
 from .src.game.bind_file.bind_file import BindFile
 from .src.game.binds.bind import Bind
 from .src.game.binds.wasd_binds import WASDBind, iWASDBind
+from .src.game.rotating_binds.changeling_binds import (
+    ChangelingRotatingBindWS,
+    ChangelingRotatingPB,
+)
 from .src.game.rotating_binds.random_binds import RandomBinds, RandomWalk
 from .src.game.rotating_binds.rotating_bind import RotatingBind
 from .src.game.rotating_binds.wasd_rotating_bind import WASDRotatingBind
@@ -28,4 +32,6 @@ __all__ = [
     "BindFileTemplate",
     "BindFileGraph",
     "BFGPublisher",
+    "ChangelingRotatingBindWS",
+    "ChangelingRotatingPB",
 ]

--- a/CityOfBinds/src/configs/constants.py
+++ b/CityOfBinds/src/configs/constants.py
@@ -17,3 +17,22 @@ class BFGConstants:
     INCLUSIVE_KEY = "on_triggers"
     EXCLUSIVE_KEY = "not_on_triggers"
     QUICK_TRIGGER_KEY = "quick_triggers"
+
+
+class ChangelingConstants:
+    DARK_NOVA = "dark nova"
+    BLACK_DWARF = "black dwarf"
+    BRIGHT_NOVA = "bright nova"
+    WHITE_DWARF = "white dwarf"
+    BOLT = "bolt"
+    BLAST = "blast"
+    DETONATION = "detonation"
+    STRIKE = "strike"
+    SMITE = "smite"
+    ANTAGONIZE = "antagonize"
+    EMMANATION = "emmanation"
+    DRAIN = "drain"
+    MIRE = "mire"
+    SCATTER = "scatter"
+    FLARE = "flare"
+    SUBLIMATION = "sublimation"

--- a/CityOfBinds/src/content_publisher/bfg_publisher.py
+++ b/CityOfBinds/src/content_publisher/bfg_publisher.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from ...utils.file_graph_publisher import _FileGraphPublisher
 from ...utils.types.str_path import StrPath
 from ..configs.constants import BFGConstants, FileExtensions
+from ..content_managers.graph.bind_file_graph import BindFileGraph
 from ..game.bind_file.bind_file import BindFile
 from ..game.binds.bind import Bind
 
@@ -77,6 +78,22 @@ class BFGPublisher(_FileGraphPublisher):
             absolute_path_links=absolute_path_links,
             file_graph_key=BFGConstants.NODE_DATA_KEY,
         )
+
+    def publish_files(
+        self,
+        file_graph: BindFileGraph,
+        directory: StrPath = "",
+        parent_folder: str = "",
+    ):
+        super().publish_files(file_graph, directory, parent_folder)
+        self._publish_install_files(directory, parent_folder)
+
+    def _publish_install_files(
+        self,
+        directory: StrPath,
+        parent_folder: str,
+    ):
+        pass
 
     # region File Linking Methods
     def _link_file(

--- a/CityOfBinds/src/content_publisher/install_files.py
+++ b/CityOfBinds/src/content_publisher/install_files.py
@@ -1,0 +1,2 @@
+from ..game.bind_file.bind_file import BindFile
+from ..game.utils.comments.comment import Comment

--- a/CityOfBinds/src/game/rotating_binds/changeling_binds.py
+++ b/CityOfBinds/src/game/rotating_binds/changeling_binds.py
@@ -1,0 +1,107 @@
+from typing import Self
+
+from ...configs.constants import ChangelingConstants
+from ...content_managers.templates.bind_template import BindTemplate
+from ..utils.triggers.trigger_mixin import _TriggerMixin
+from .rotating_bind import RotatingBind
+
+
+class _ChangelingRotatingBind(_TriggerMixin, RotatingBind):
+    LOOP_DELAY = 1
+    NOVA_FORM: str
+    DWARF_FORM: str
+
+    def __init__(
+        self, trigger: str, is_silent: bool = True, absolute_path_links: bool = False
+    ):
+        _TriggerMixin.__init__(self, trigger)
+        RotatingBind.__init__(
+            self, is_silent=is_silent, absolute_path_links=absolute_path_links
+        )
+        self._form_changes: list[str] = []
+        self._form_powers: list[str] = []
+        self.bind_template: BindTemplate = BindTemplate(self.trigger)
+
+    def add_bolt(self, count: int = 1) -> Self:
+        return self._add_nova_power(ChangelingConstants.BOLT, count)
+
+    def add_blast(self, count: int = 1) -> Self:
+        return self._add_nova_power(ChangelingConstants.BLAST, count)
+
+    def add_detonation(self, count: int = 1) -> Self:
+        return self._add_nova_power(ChangelingConstants.DETONATION, count)
+
+    def add_strike(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.STRIKE, count)
+
+    def add_smite(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.SMITE, count)
+
+    def add_antagonize(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.ANTAGONIZE, count)
+
+    def _build_bind_files(self):
+        self._build_changeling_bind_template(self.bind_template)
+        self.bind_file_template.add_bind_template(
+            self.bind_template, trigger_on_up_press=True
+        )
+        return super()._build_bind_files()
+
+    def _add_nova_power(self, power: str, count: int = 1) -> Self:
+        return self._add_form_power(self.NOVA_FORM, power, count)
+
+    def _add_dwarf_power(self, power: str, count: int = 1) -> Self:
+        return self._add_form_power(self.DWARF_FORM, power, count)
+
+    def _add_form_power(self, form: str, power: str, count: int = 1) -> Self:
+        for _ in range(count):
+            self._form_changes.append(form)
+            self._form_powers.append(f"{form} {power}")
+        return self
+
+    def _build_changeling_bind_template(self, template: BindTemplate):
+        template.add_toggle_on_power_pool(self._form_changes)
+        template.add_power_pool(self._form_powers)
+        template.add_toggle_off_power_pool(self._form_changes)
+
+
+class ChangelingRotatingBindWS(_ChangelingRotatingBind):
+    NOVA_FORM = ChangelingConstants.DARK_NOVA
+    DWARF_FORM = ChangelingConstants.BLACK_DWARF
+
+    def __init__(
+        self, trigger: str, is_silent: bool = True, absolute_path_links: bool = False
+    ):
+        super().__init__(
+            trigger, is_silent=is_silent, absolute_path_links=absolute_path_links
+        )
+
+    def add_emmanation(self, count: int = 1) -> Self:
+        return self._add_nova_power(ChangelingConstants.EMMANATION, count)
+
+    def add_drain(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.DRAIN, count)
+
+    def add_mire(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.MIRE, count)
+
+
+class ChangelingRotatingPB(_ChangelingRotatingBind):
+    NOVA_FORM = ChangelingConstants.BRIGHT_NOVA
+    DWARF_FORM = ChangelingConstants.WHITE_DWARF
+
+    def __init__(
+        self, trigger: str, is_silent: bool = True, absolute_path_links: bool = False
+    ):
+        super().__init__(
+            trigger, is_silent=is_silent, absolute_path_links=absolute_path_links
+        )
+
+    def add_scatter(self, count: int = 1) -> Self:
+        return self._add_nova_power(ChangelingConstants.SCATTER, count)
+
+    def add_flare(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.FLARE, count)
+
+    def add_sublimation(self, count: int = 1) -> Self:
+        return self._add_dwarf_power(ChangelingConstants.SUBLIMATION, count)

--- a/CityOfBinds/src/game/rotating_binds/changeling_binds.py
+++ b/CityOfBinds/src/game/rotating_binds/changeling_binds.py
@@ -7,7 +7,6 @@ from .rotating_bind import RotatingBind
 
 
 class _ChangelingRotatingBind(_TriggerMixin, RotatingBind):
-    LOOP_DELAY = 1
     NOVA_FORM: str
     DWARF_FORM: str
 
@@ -16,11 +15,14 @@ class _ChangelingRotatingBind(_TriggerMixin, RotatingBind):
     ):
         _TriggerMixin.__init__(self, trigger)
         RotatingBind.__init__(
-            self, is_silent=is_silent, absolute_path_links=absolute_path_links
+            self,
+            is_silent=is_silent,
+            absolute_path_links=absolute_path_links,
+            loop_delay=1,
         )
         self._form_changes: list[str] = []
         self._form_powers: list[str] = []
-        self.bind_template: BindTemplate = BindTemplate(self.trigger)
+        self.changeling_bind_template: BindTemplate = BindTemplate(self.trigger)
 
     def add_bolt(self, count: int = 1) -> Self:
         return self._add_nova_power(ChangelingConstants.BOLT, count)
@@ -41,9 +43,9 @@ class _ChangelingRotatingBind(_TriggerMixin, RotatingBind):
         return self._add_dwarf_power(ChangelingConstants.ANTAGONIZE, count)
 
     def _build_bind_files(self):
-        self._build_changeling_bind_template(self.bind_template)
+        self._build_changeling_bind_template(self.changeling_bind_template)
         self.bind_file_template.add_bind_template(
-            self.bind_template, trigger_on_up_press=True
+            self.changeling_bind_template, trigger_on_up_press=True
         )
         return super()._build_bind_files()
 

--- a/CityOfBinds/src/game/rotating_binds/generic_rotating_binds.py
+++ b/CityOfBinds/src/game/rotating_binds/generic_rotating_binds.py
@@ -78,6 +78,10 @@ class _GenericRotatingBind(ABC):
             conditions[BFGConstants.EXCLUSIVE_KEY] = (
                 self.bind_file_template.exclude_triggers
             )
+        if self.bind_file_template.quick_triggers:
+            conditions[BFGConstants.QUICK_TRIGGER_KEY] = (
+                self.bind_file_template.quick_triggers
+            )
         return conditions
 
     def _create_bind_file_graph(
@@ -96,10 +100,16 @@ class _GenericRotatingBind(ABC):
 
 
 class _LoopTopology:
+    LOOP_DELAY = 0
+
     def _connect_bind_file_graph(
         self, bfg: BindFileGraph, bind_file_indexes: list[int], trigger_conditions: dict
     ):
-        bfg.loop(bind_file_indexes, trigger_conditions=trigger_conditions)
+        bfg.loop(
+            bind_file_indexes,
+            trigger_conditions=trigger_conditions,
+            delay=self.LOOP_DELAY,
+        )
 
 
 class _RandomOrder:

--- a/CityOfBinds/src/game/rotating_binds/generic_rotating_binds.py
+++ b/CityOfBinds/src/game/rotating_binds/generic_rotating_binds.py
@@ -100,7 +100,8 @@ class _GenericRotatingBind(ABC):
 
 
 class _LoopTopology:
-    LOOP_DELAY = 0
+    def __init__(self, loop_delay: int = 0):
+        self.loop_delay = loop_delay
 
     def _connect_bind_file_graph(
         self, bfg: BindFileGraph, bind_file_indexes: list[int], trigger_conditions: dict
@@ -108,10 +109,13 @@ class _LoopTopology:
         bfg.loop(
             bind_file_indexes,
             trigger_conditions=trigger_conditions,
-            delay=self.LOOP_DELAY,
+            delay=self.loop_delay,
         )
 
 
 class _RandomOrder:
+    def __init__(self, random_factor: int = 1):
+        self.random_factor = random_factor
+
     def _index_bind_files(self, bind_files: list[BindFile]):
-        random.shuffle(bind_files)
+        random.shuffle(bind_files * self.random_factor)

--- a/CityOfBinds/src/game/rotating_binds/random_binds.py
+++ b/CityOfBinds/src/game/rotating_binds/random_binds.py
@@ -1,14 +1,9 @@
-from typing import TYPE_CHECKING
-
 from ...configs.constants import BFGConstants
 from ...content_managers.graph.bind_file_graph import BindFileGraph
 from ..bind_file.bind_file import BindFile
 from .generic_rotating_binds import _RandomOrder
 from .rotating_bind import RotatingBind
 from .wasd_rotating_bind import WASDRotatingBind
-
-if TYPE_CHECKING:
-    pass
 
 
 class RandomBinds(RotatingBind, _RandomOrder):
@@ -17,16 +12,15 @@ class RandomBinds(RotatingBind, _RandomOrder):
         random_factor: int = 10,
         is_silent: bool = True,
         absolute_path_links: bool = False,
+        loop_delay: int = 0,
     ):
         RotatingBind.__init__(
-            self, is_silent=is_silent, absolute_path_links=absolute_path_links
+            self,
+            is_silent=is_silent,
+            absolute_path_links=absolute_path_links,
+            loop_delay=loop_delay,
         )
-        self.random_factor = random_factor
-
-    def _build_bind_files(self) -> list[BindFile]:
-        bind_files = super()._build_bind_files()
-        extended_bind_files = bind_files * self.random_factor
-        return extended_bind_files
+        _RandomOrder.__init__(self, random_factor=random_factor)
 
 
 class RandomWalk(WASDRotatingBind, _RandomOrder):
@@ -41,7 +35,9 @@ class RandomWalk(WASDRotatingBind, _RandomOrder):
             include_jump=include_jump,
             is_silent=is_silent,
             absolute_path_links=absolute_path_links,
+            loop_delay=0,
         )
+        _RandomOrder.__init__(self, random_factor=1)
 
     def _connect_bind_file_graph(
         self, bfg: BindFileGraph, bind_file_indexes: list[int], trigger_conditions: dict

--- a/CityOfBinds/src/game/rotating_binds/rotating_bind.py
+++ b/CityOfBinds/src/game/rotating_binds/rotating_bind.py
@@ -3,7 +3,13 @@ from .generic_rotating_binds import _GenericRotatingBind, _LoopTopology
 
 
 class RotatingBind(_LoopTopology, _GenericRotatingBind):
-    def __init__(self, is_silent: bool = True, absolute_path_links: bool = False):
+    def __init__(
+        self,
+        is_silent: bool = True,
+        absolute_path_links: bool = False,
+        loop_delay: int = 0,
+    ):
+        _LoopTopology.__init__(self, loop_delay=loop_delay)
         _GenericRotatingBind.__init__(
             self, is_silent=is_silent, absolute_path_links=absolute_path_links
         )

--- a/CityOfBinds/src/game/rotating_binds/wasd_rotating_bind.py
+++ b/CityOfBinds/src/game/rotating_binds/wasd_rotating_bind.py
@@ -14,7 +14,9 @@ class WASDRotatingBind(_LoopTopology, _GenericRotatingBind):
         include_jump: bool = False,
         is_silent: bool = True,
         absolute_path_links: bool = False,
+        loop_delay: int = 0,
     ):
+        _LoopTopology.__init__(self, loop_delay=loop_delay)
         _GenericRotatingBind.__init__(
             self, is_silent=is_silent, absolute_path_links=absolute_path_links
         )

--- a/CityOfBinds/src/game/rotating_binds/wasd_rotating_bind.py
+++ b/CityOfBinds/src/game/rotating_binds/wasd_rotating_bind.py
@@ -2,6 +2,9 @@ import copy
 
 from ...content_managers.templates.bind_file_template import RotationPolicy
 from ...content_managers.templates.bind_template import WASDBindTemplate
+from ...content_managers.utils.commands_template import (
+    _CommandsTemplate,  # TODO: implement base wasd bind to use commandstemplate (2025/12/27)
+)
 from .generic_rotating_binds import _GenericRotatingBind, _LoopTopology
 
 

--- a/CityOfBinds/utils/file_graph_publisher.py
+++ b/CityOfBinds/utils/file_graph_publisher.py
@@ -12,7 +12,7 @@ PathFactoryConstructor: TypeAlias = Callable[[int, StrPath], "PathFactoryProtoco
 
 class FileGraphDefaults:
     FILE_GRAPH_KEY = "file"
-    PARENT_FOLDER = "file_graph"
+    PARENT_FOLDER = "graph_files"
     PUBLISH_DIRECTORY = "."
     ABSOLUTE_PATH_LINKS = False
     ARCHIVE_FORMAT = "zip"

--- a/CityOfBinds/utils/pathgenerator.py
+++ b/CityOfBinds/utils/pathgenerator.py
@@ -136,10 +136,14 @@ class PathGenerator:
         return depth_capacities
 
     def _calculate_part_width(self, file_count: int, max_files_per_folder: int) -> int:
+        if file_count == 0:
+            return 1
         max_index = min(file_count, max_files_per_folder) - 1
         return len(self._base_converter[max_index])
 
     def _calculate_root_width(self, file_count: int, capacity: int) -> int:
+        if file_count == 0:
+            return 1
         num_root_folders = math.ceil(file_count / capacity)
         max_root_index = num_root_folders - 1
         return len(self._base_converter[max_root_index])

--- a/tests/examples/test_changeling_bind.py
+++ b/tests/examples/test_changeling_bind.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from CityOfBinds import ChangelingRotatingBindWS
+
+
+def test_small_changeling_bind_creation(in_tmp_dir):
+    changeling = ChangelingRotatingBindWS("SHIFT+5")
+
+    changeling.add_bolt()
+    changeling.add_blast()
+    changeling.add_detonation()
+
+    changeling.publish_bind_files(parent_folder_name="ch", directory="binds_folder")
+
+    # region validation
+    # expected binds in each file
+    expected_file_contents = {
+        "binds_folder/ch/0.txt": [
+            'SHIFT+5 "+$$powexectoggleon dark nova$$powexecname dark nova bolt$$powexectoggleoff dark nova$$bindloadfilesilent ch/3.txt"',
+        ],
+        "binds_folder/ch/3.txt": [
+            'SHIFT+5 "+$$powexectoggleon dark nova$$powexecname dark nova bolt$$powexectoggleoff dark nova$$bindloadfilesilent ch/1.txt"',
+        ],
+        "binds_folder/ch/1.txt": [
+            'SHIFT+5 "+$$powexectoggleon dark nova$$powexecname dark nova blast$$powexectoggleoff dark nova$$bindloadfilesilent ch/4.txt"',
+        ],
+        "binds_folder/ch/4.txt": [
+            'SHIFT+5 "+$$powexectoggleon dark nova$$powexecname dark nova blast$$powexectoggleoff dark nova$$bindloadfilesilent ch/2.txt"',
+        ],
+        "binds_folder/ch/2.txt": [
+            'SHIFT+5 "+$$powexectoggleon dark nova$$powexecname dark nova detonation$$powexectoggleoff dark nova$$bindloadfilesilent ch/5.txt"',
+        ],
+        "binds_folder/ch/5.txt": [
+            'SHIFT+5 "+$$powexectoggleon dark nova$$powexecname dark nova detonation$$powexectoggleoff dark nova$$bindloadfilesilent ch/0.txt"',
+        ],
+    }
+
+    # verify contents of each file to ensure binds are correct
+    for file_path in expected_file_contents.keys():
+        assert Path(file_path).is_file()
+        with open(file_path, "r") as f:
+            contents = f.read()
+        for expected_bind in expected_file_contents[file_path]:
+            assert expected_bind in contents
+
+    # endregion
+
+
+def test_warshade_changeling_bind(in_tmp_dir):
+
+    # region setup
+    # initialize the rotating bind
+    changeling = ChangelingRotatingBindWS("SHIFT+5")
+
+    # define attack order
+    (
+        changeling.add_bolt()
+        .add_blast()
+        .add_bolt()
+        .add_detonation()
+        .add_bolt()
+        .add_emmanation()
+    )
+
+    # publish the bind file
+    changeling.publish_bind_files(parent_folder_name="ch")


### PR DESCRIPTION
This pull request introduces significant new functionality for "Changeling" rotating binds, refactors the rotating binds infrastructure to support more flexible behaviors, and improves file and path handling. The most important changes are grouped and summarized below.

### New Changeling Rotating Binds

* Added new classes `ChangelingRotatingBindWS` and `ChangelingRotatingPB` for specialized changeling rotating binds, including their implementation and public API exposure in `__init__.py`. These classes support chaining of nova and dwarf powers and are validated with new tests. [[1]](diffhunk://#diff-648f4e9699c9e088291e533259a88ac9dc9ea6e595aebc5990287807177878dcR13-R16) [[2]](diffhunk://#diff-648f4e9699c9e088291e533259a88ac9dc9ea6e595aebc5990287807177878dcR35-R36) [[3]](diffhunk://#diff-4def6f6c36b2359bd0653e6606e8d1c74dbb959a94d0500e3f62dfc16b93aaf1R1-R109) [[4]](diffhunk://#diff-2aad499d2201bdac5eab780bf8a18597ea22f2c52fb535e4017b7f60820a7ee5R1-R66)

* Introduced `ChangelingConstants` to centralize power and form names used by changeling binds.

### Rotating Binds Infrastructure Enhancements

* Refactored `RotatingBind` and `WASDRotatingBind` to accept a `loop_delay` parameter, allowing control over the looping delay for bind rotations. [[1]](diffhunk://#diff-f70a2d4ef702e47910141289b9f2ea1a1d22159a4aeecf3430bbfa1108fb5f61L6-R12) [[2]](diffhunk://#diff-c312a0c036eb8fa32690650929dd2e4ef5899aceb8f5dec5531a4d13013555d8R17-R19)

* Updated `_LoopTopology` and `_RandomOrder` mixins to support initialization with `loop_delay` and `random_factor` respectively, and refactored their usage in `RandomBinds` and `RandomWalk` for more flexible and DRY code. [[1]](diffhunk://#diff-ec586b46814295ae17fda805c51aa3a5b67f43e053a81312d343a58e1ab4c8cdR103-R121) [[2]](diffhunk://#diff-0759d0df1d0d01006c95f698e5a1deac3dcfdbbae78ee2617e913f708ca271aeL1-R23) [[3]](diffhunk://#diff-0759d0df1d0d01006c95f698e5a1deac3dcfdbbae78ee2617e913f708ca271aeR38-R40)

### File Publishing and Path Handling Improvements

* Changed the default parent folder for file graph publishing from `file_graph` to `graph_files` in `FileGraphDefaults`.

* Added a stub for install file publishing in `BFGPublisher` and imported `BindFileGraph` to support future enhancements. [[1]](diffhunk://#diff-1844dd5375218633c84f2615494ab4c61d751a4913caa3eb2cadff7ee147b1a3R6) [[2]](diffhunk://#diff-1844dd5375218633c84f2615494ab4c61d751a4913caa3eb2cadff7ee147b1a3R82-R97)

* Improved path generation logic to handle the edge case of zero files, ensuring at least one folder/part is created.

### Miscellaneous

* Added support for the `quick_triggers` key in trigger condition generation for bind files.

* Added missing imports in `install_files.py` for future development.